### PR TITLE
avoid running parsnip-related initialization twice

### DIFF
--- a/R/package.R
+++ b/R/package.R
@@ -9,6 +9,8 @@
 #' @name cuml
 NULL
 
+.cuml_parsnip_init_done <- FALSE
+
 .onLoad <- function(libname, pkgname) {
   if (!has_libcuml()) {
     if (is.na(Sys.getenv("_R_CHECK_CRAN_INCOMING_", unset = NA))) {
@@ -32,7 +34,10 @@ NULL
     }
   }
 
-  register_rand_forest_model(pkgname)
-  register_svm_model(pkgname)
-  register_knn_model(pkgname)
+  if (identical(.cuml_parsnip_init_done, FALSE)) {
+    register_rand_forest_model(pkgname)
+    register_svm_model(pkgname)
+    register_knn_model(pkgname)
+    .cuml_parsnip_init_done <<- TRUE
+  }
 }


### PR DESCRIPTION
Signed-off-by: Yitao Li <yitao@rstudio.com>