### PR TITLE
verify `has_libcuml()` returns `TRUE` in test env

### DIFF
--- a/tests/testthat/helper-initialize.R
+++ b/tests/testthat/helper-initialize.R
@@ -42,13 +42,8 @@ predict_in_sub_proc <- function(model_state, data, expected_mode,
     expect_libcuml_impl()
 
     model <- cuml_unserialize(model_state)
-    missing_cls <- setdiff(expected_model_cls, class(model))
-    if (length(missing_cls) > 0) {
-      stop(
-        "Unserialized model is missing the following classes:\b",
-        paste(missing_cls, collapse = " "),
-        "\n"
-      )
+    for (cls in expected_model_cls) {
+      testthat::expect_s3_class(model, cls)
     }
     stopifnot(identical(model$mode, expected_mode))
 

--- a/tests/testthat/test-svm-serde.R
+++ b/tests/testthat/test-svm-serde.R
@@ -3,18 +3,11 @@ test_that("SVM regressor can be serialized and unserialized correctly", {
   model_state <- cuml_serialize(model)
 
   expected_preds <- predict(model, mtcars)
-  actual_preds <- callr::r(
-    function(model_state) {
-      library(cuml)
-
-      model <- cuml_unserialize(model_state)
-      stopifnot("cuml_svr" %in% class(model))
-      stopifnot(identical(model$mode, "regression"))
-
-      predict(model, mtcars)
-    },
-    args = list(model_state = model_state),
-    stdout = "", stderr = ""
+  actual_preds <- predict_in_sub_proc(
+    model_state,
+    data = mtcars,
+    expected_mode = "regression",
+    expected_model_cls = "cuml_svr"
   )
 
   expect_equal(expected_preds, actual_preds)


### PR DESCRIPTION
It seems like a good idea to verify `has_libcuml()` returns `TRUE` within both the `testthat` process and the `callr` sub-process.

Signed-off-by: Yitao Li <yitao@rstudio.com>